### PR TITLE
Feature/#11-3 게시글 좋아요 N:M 관계 기본 구축 작업

### DIFF
--- a/src/main/java/toy/com/post/controller/PostController.java
+++ b/src/main/java/toy/com/post/controller/PostController.java
@@ -10,7 +10,7 @@ import org.springframework.web.bind.annotation.RestController;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
-import toy.com.post.dto.PostDetailInfoResponse;
+import toy.com.post.dto.response.PostDetailInfoResponse;
 import toy.com.post.dto.response.PostListsResponse;
 import toy.com.post.service.PostReadService;
 

--- a/src/main/java/toy/com/post/domain/PostAdditional.java
+++ b/src/main/java/toy/com/post/domain/PostAdditional.java
@@ -1,0 +1,34 @@
+package toy.com.post.domain;
+
+import javax.persistence.CascadeType;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.OneToMany;
+import javax.persistence.Table;
+import lombok.AccessLevel;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+import toy.com.common.entity.BaseTimeEntity;
+import toy.com.user.domain.User;
+
+@Entity
+@Getter
+@ToString
+@EqualsAndHashCode(of = "id", callSuper = false)
+@Table(name = "post_additional")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PostAdditional extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @OneToMany(fetch = FetchType.LAZY, cascade = CascadeType.ALL, mappedBy = "post_additional")
+    private User reactionPostUser;
+
+}

--- a/src/main/java/toy/com/post/domain/Reply.java
+++ b/src/main/java/toy/com/post/domain/Reply.java
@@ -1,5 +1,6 @@
 package toy.com.post.domain;
 
+import java.util.Objects;
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
@@ -11,14 +12,17 @@ import javax.persistence.ManyToOne;
 import javax.persistence.Table;
 
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.ToString;
 import toy.com.common.entity.BaseTimeEntity;
 import toy.com.user.domain.User;
 
 @Entity
 @Getter
+@ToString(exclude = "post")
 @EqualsAndHashCode(of = "id", callSuper = false)
 @Table(name = "reply")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -28,25 +32,44 @@ public class Reply extends BaseTimeEntity {
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
 
-	@JoinColumn(name = "post_id")
-	@ManyToOne(fetch = FetchType.LAZY)
-	private Post post;
-
-	@JoinColumn(name = "reply_id")
-	@ManyToOne(fetch = FetchType.LAZY)
-	private User replyWriter;
-
 	@Lob
 	private String content;
 
 	private int replyLikes;
 
-	@JoinColumn(name = "reaction_id")
+	@JoinColumn(name = "post_id")
 	@ManyToOne(fetch = FetchType.LAZY)
-	private User reactonUser;
+	private Post post;
+
+	@JoinColumn(name = "reply_write_user_id")
+	@ManyToOne(fetch = FetchType.LAZY)
+	private User replyWriter;
+
+	@JoinColumn(name = "reply_reaction_user_id")
+	@ManyToOne(fetch = FetchType.LAZY)
+	private User reactionUser;
+
+	public void applyPost(Post post) {
+		if (this.post != null) {
+			this.post.getReplies().remove(this);
+		}
+		this.post = post;
+		if (!post.getReplies().contains(this)) {
+			post.getReplies().add(this);
+		}
+	}
+
+	@Builder
+	public Reply(String content, int replyLikes, User replyWriter, User reactionUser) {
+		this.content = content;
+		this.replyLikes = replyLikes;
+		this.replyWriter = replyWriter;
+		this.reactionUser = reactionUser;
+	}
 
 	public boolean isReactionReply(Long userId) {
-		return reactonUser.getId().equals(userId);
+		if (Objects.isNull(userId)) return false;
+		return reactionUser.getId().equals(userId);
 	}
 
 }

--- a/src/main/java/toy/com/post/domain/ReplyAdditional.java
+++ b/src/main/java/toy/com/post/domain/ReplyAdditional.java
@@ -1,0 +1,30 @@
+package toy.com.post.domain;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.Table;
+import lombok.AccessLevel;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+import toy.com.common.entity.BaseTimeEntity;
+
+@Entity
+@Getter
+@ToString
+@EqualsAndHashCode(of = "id", callSuper = false)
+@Table(name = "reply_additional")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ReplyAdditional extends BaseTimeEntity {
+
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+
+
+}

--- a/src/main/java/toy/com/post/dto/response/PostDetailInfoResponse.java
+++ b/src/main/java/toy/com/post/dto/response/PostDetailInfoResponse.java
@@ -1,4 +1,4 @@
-package toy.com.post.dto;
+package toy.com.post.dto.response;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -35,7 +35,7 @@ public record PostDetailInfoResponse(@Schema(description = "게시글 id")
 									 @Schema(description = "게시글 생성일자")
 									 LocalDateTime createdAt) {
 
-	public static PostDetailInfoResponse of(Post post) {
+	public static PostDetailInfoResponse ofList(Post post) {
 		return new PostDetailInfoResponseBuilder()
 			.postId(post.getId())
 			.title(post.getPostTitle())
@@ -45,7 +45,6 @@ public record PostDetailInfoResponse(@Schema(description = "게시글 id")
 			.createdAt(post.getCreatedAt())
 			.likeCounts(post.getLikeCounts())
 			.viewCounts(post.getViewCounts())
-			.reply(post.getReplies())
 			.build();
 	}
 
@@ -59,6 +58,7 @@ public record PostDetailInfoResponse(@Schema(description = "게시글 id")
 			.createdAt(post.getCreatedAt())
 			.likeCounts(post.getLikeCounts())
 			.viewCounts(post.getViewCounts())
+			.reply(post.getReplies())
 			.postMyReaction(post.isReactionPost(userId))
 			.build();
 	}

--- a/src/main/java/toy/com/post/dto/response/PostListsResponse.java
+++ b/src/main/java/toy/com/post/dto/response/PostListsResponse.java
@@ -4,7 +4,6 @@ import java.util.List;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
-import toy.com.post.dto.PostDetailInfoResponse;
 
 @Builder
 public record PostListsResponse(@Schema(description = "현재 요청된 페이지")

--- a/src/main/java/toy/com/post/repository/PostRepository.java
+++ b/src/main/java/toy/com/post/repository/PostRepository.java
@@ -8,8 +8,7 @@ import toy.com.post.domain.Post;
 
 public interface PostRepository extends JpaRepository<Post, Long> {
 
-	Page<Post> findAll(Pageable pageable);
-
+	Page<Post> findAllByOrderByCreatedAtDesc(Pageable pageable);
 	int countBy();
 
 }

--- a/src/main/java/toy/com/post/service/PostReadService.java
+++ b/src/main/java/toy/com/post/service/PostReadService.java
@@ -2,18 +2,15 @@ package toy.com.post.service;
 
 import static toy.com.exception.code.ErrorCode.*;
 
-import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
-
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import lombok.RequiredArgsConstructor;
 import toy.com.exception.CustomException;
-import toy.com.post.domain.Post;
-import toy.com.post.dto.PostDetailInfoResponse;
+import toy.com.post.dto.response.PostDetailInfoResponse;
 import toy.com.post.dto.response.PostListsResponse;
 import toy.com.post.repository.PostRepository;
 
@@ -28,27 +25,26 @@ public class PostReadService {
 
 	public PostListsResponse getPostListPerPage(Pageable page) {
 
-		List<PostDetailInfoResponse> postResultsPerPage = postRepository.findAll(page).stream()
-			.sorted(Comparator.comparing(Post::getCreatedAt))
-			.map(PostDetailInfoResponse::of)
-			.collect(Collectors.toList());
-
 		int totalPosts = postRepository.countBy();
 
 		return PostListsResponse.builder()
-			.postResults(postResultsPerPage)
+			.postResults(getPostPerPage(page))
 			.page(page.getPageNumber())
-			.perCounts(postResultsPerPage.size())
+			.perCounts(getPostPerPage(page).size())
 			.totalPosts(totalPosts)
 			.totalPages(totalPosts / DEFAULT_PAGE_COUNT)
 			.build();
 	}
 
-	public PostDetailInfoResponse getPostDetail(Long postId) {
+	private List<PostDetailInfoResponse> getPostPerPage(Pageable page) {
+		return postRepository.findAllByOrderByCreatedAtDesc(page).stream()
+			.map(PostDetailInfoResponse::ofList)
+			.collect(Collectors.toList());
+	}
 
+	public PostDetailInfoResponse getPostDetail(Long postId) {
 		// sample userId;
 		Long sampleUserId = 1L;
-
 		return postRepository.findById(postId)
 			.map(post -> PostDetailInfoResponse.ofDetail(post, sampleUserId))
 			.orElseThrow(() -> new CustomException(NOT_FOUND_POST));

--- a/src/main/java/toy/com/post/service/PostWriteService.java
+++ b/src/main/java/toy/com/post/service/PostWriteService.java
@@ -6,8 +6,8 @@ import org.springframework.stereotype.Service;
 
 import toy.com.post.repository.PostRepository;
 
-@Service
-@Transactional
+//@Service
+//@Transactional
 public class PostWriteService {
 
 	private PostRepository postRepository;

--- a/src/main/java/toy/com/user/domain/User.java
+++ b/src/main/java/toy/com/user/domain/User.java
@@ -1,7 +1,5 @@
 package toy.com.user.domain;
 
-import java.util.ArrayList;
-import java.util.List;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
@@ -9,15 +7,12 @@ import javax.persistence.Enumerated;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
-import javax.persistence.OneToMany;
 import javax.persistence.Table;
-
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import toy.com.post.domain.Post;
 
 @Getter
 @EqualsAndHashCode(of = "id")
@@ -26,31 +21,32 @@ import toy.com.post.domain.Post;
 @Entity
 public class User {
 
-	@Id
-	@GeneratedValue(strategy = GenerationType.IDENTITY)
-	private Long id;
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
 
-	@Column(nullable = false, length = 50)
-	private String email;
+    @Column(nullable = false, length = 50)
+    private String email;
 
-	@Column(nullable = false)
-	private String password;
+    @Column(nullable = false)
+    private String password;
 
-	@Column(nullable = false)
-	private String nickname;
+    @Column(nullable = false)
+    private String nickname;
 
-	@Enumerated(EnumType.STRING)
-	private UserRole userRole;
+    @Enumerated(EnumType.STRING)
+    private UserRole userRole;
 
-	@Enumerated(EnumType.STRING)
-	private UserStatus userStatus;
+    @Enumerated(EnumType.STRING)
+    private UserStatus userStatus;
 
-	@Builder
-	public User(String email, String password, String nickname, UserRole userRole, UserStatus userStatus) {
-		this.email = email;
-		this.password = password;
-		this.nickname = nickname;
-		this.userRole = userRole;
-		this.userStatus = userStatus;
-	}
+    @Builder
+    public User(String email, String password, String nickname, UserRole userRole,
+        UserStatus userStatus) {
+        this.email = email;
+        this.password = password;
+        this.nickname = nickname;
+        this.userRole = userRole;
+        this.userStatus = userStatus;
+    }
 }

--- a/src/test/java/toy/com/post/service/PostReadServiceTest.java
+++ b/src/test/java/toy/com/post/service/PostReadServiceTest.java
@@ -1,0 +1,109 @@
+package toy.com.post.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.transaction.annotation.Transactional;
+import toy.com.post.domain.Post;
+import toy.com.post.domain.PostCategory;
+import toy.com.post.domain.PostStatus;
+import toy.com.post.domain.Reply;
+import toy.com.post.dto.response.PostDetailInfoResponse;
+import toy.com.post.dto.response.PostListsResponse;
+import toy.com.post.repository.PostRepository;
+import toy.com.user.domain.User;
+import toy.com.user.repository.UserRepository;
+
+@SpringBootTest
+@Transactional
+class PostReadServiceTest {
+
+    private static final int PAGE_SIZE = 20;
+
+    @Autowired
+    private PostReadService postReadService;
+
+    @Autowired
+    private PostRepository postRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @BeforeEach
+    void setUp() {
+
+        List<Post> bulkInsert = new ArrayList<>();
+
+        User samplePostWriterUser = User.builder()
+            .email("useremail1@naver.com")
+            .password("xzcjzkxcjxz1212")
+            .nickname("닉네임11111")
+            .build();
+
+        User sampleReplyWriterUser = User.builder()
+            .email("useremail2@naver.com")
+            .password("xzcjzkxcjxz1212")
+            .nickname("닉네임22222")
+            .build();
+
+        for (int i = 0; i < 100; i ++) {
+            Reply sampleReply = Reply.builder()
+                .content("샘플 답글")
+                .replyLikes(1)
+                .replyWriter(sampleReplyWriterUser)
+                .build();
+
+            Post samplePost = Post.builder()
+                .postTitle("샘플 포스트")
+                .postContent("샘플내용")
+                .postStatus(PostStatus.NORMAL)
+                .postCategory(PostCategory.DEFAULT)
+                .postWriter(samplePostWriterUser)
+                .reply(sampleReply)
+                .build();
+
+            sampleReply.applyPost(samplePost);
+
+            bulkInsert.add(samplePost);
+        }
+
+        userRepository.save(samplePostWriterUser);
+        userRepository.save(sampleReplyWriterUser);
+
+        postRepository.saveAll(bulkInsert);
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {1, 2, 3, 4})
+    @DisplayName("게시글이 페이지 네이션 개수만큼 갖고와지는지 확인")
+    void getPostList(int page) {
+
+        Pageable pageable = PageRequest.of(page, PAGE_SIZE);
+
+        PostListsResponse response = postReadService.getPostListPerPage(pageable);
+
+        assertThat(response.postResults().size()).isEqualTo(PAGE_SIZE);
+    }
+
+    @Test
+    @DisplayName("게시글 상세 내용 조회시 답글이 있는 경우 답글이 같이 내려오는지 확인")
+    void getPostDetail() {
+
+        Long samplePostId = 1L;
+
+        PostDetailInfoResponse infoResponse = postReadService.getPostDetail(samplePostId);
+
+        System.out.println(infoResponse);
+    }
+
+}


### PR DESCRIPTION
## 작업에 대한 간단한 요약
게시글, 댓글 좋아요시 N:M 관계로 인해 additional 엔티티 만들어서 해결하기 위한 기본 작업 구축 및 
게시글 조회 테스트 코드 작성하였습니다

### 변경내역
-  additional entity 추가
- 게시글 조회 서비스 코드 작성 추가


### 어떤부분에 집중해서 리뷰하면좋을지
게시글 리스트 조회시 jpa의 pageable 기능 사용하여 구현하였으며, 해당 부분 테스트 진행하였습니다.
N:M 관계 해결을 위해 중간다리 역할 하는 엔티티를 구현하였는데, 더 좋은 방법이 있으명 조언 부탁드립니다


### 이슈번호 외 기타내용
