### PR TITLE
Feature/#11-6 게시글, 댓글 컨트롤러 테스트 추가

### DIFF
--- a/src/main/java/toy/com/post/controller/PostController.java
+++ b/src/main/java/toy/com/post/controller/PostController.java
@@ -2,13 +2,16 @@ package toy.com.post.controller;
 
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
+import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 import io.swagger.v3.oas.annotations.Operation;
@@ -33,19 +36,20 @@ public class PostController {
 	private final PostWriteService postWriteService;
 
 	@Operation(summary = "게시글 작성", description = "게시글 작성을 요청한다")
-	@PostMapping(value = "/write", produces = "application/json")
+	@ResponseStatus(HttpStatus.CREATED)
+	@PostMapping(value = "/write")
 	public void createPost(@RequestBody PostCreateRequest postCreateRequest) {
 		postWriteService.createPost(postCreateRequest);
 	}
 
 	@Operation(summary = "게시글 수정", description = "게시글 수정을 요청한다")
-	@PatchMapping(value = "/modify", produces = "application/json")
+	@PatchMapping(value = "/modify")
 	public void modifyPost(@RequestBody PostModifyRequest postModifyRequest) {
 		postWriteService.modifyPost(postModifyRequest);
 	}
 
 	@Operation(summary = "게시글 삭제", description = "게시글 삭제를 요청한다")
-	@DeleteMapping(value = "/delete/{postId}", produces = "application/json")
+	@DeleteMapping(value = "/delete/{postId}")
 	public void modifyPost(@PathVariable Long postId) {
 		postWriteService.deletePost(postId);
 	}
@@ -63,7 +67,7 @@ public class PostController {
 	}
 
 	@Operation(summary = "게시글 좋아요", description = "게시글 좋아요를 한다")
-	@PostMapping(value = "/like/{postId}", produces = "application/json")
+	@PutMapping(value = "/like/{postId}")
 	public void likePost(@PathVariable Long postId) {
 		postWriteService.updateLikePost(postId);
 	}

--- a/src/main/java/toy/com/post/controller/ReplyController.java
+++ b/src/main/java/toy/com/post/controller/ReplyController.java
@@ -1,5 +1,6 @@
 package toy.com.post.controller;
 
+import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -7,6 +8,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 import io.swagger.v3.oas.annotations.Operation;
@@ -25,25 +27,26 @@ public class ReplyController {
 	private final ReplyWriteService replyWriteService;
 
 	@Operation(summary = "댓글 작성", description = "댓글을 작성한다")
-	@PostMapping(value = "/write", produces = "application/json")
+	@ResponseStatus(HttpStatus.CREATED)
+	@PostMapping(value = "/write")
 	public void createReply(@RequestBody ReplyCreateRequest request) {
 		replyWriteService.createReply(request);
 	}
 
 	@Operation(summary = "댓글 수정", description = "댓글을 수정한다")
-	@PatchMapping(value = "/modify", produces = "application/json")
+	@PatchMapping(value = "/modify")
 	public void modifyReply(@RequestBody ReplyModifyRequest request) {
 		replyWriteService.modifyReply(request);
 	}
 
 	@Operation(summary = "댓글 삭제", description = "댓글을 삭제한다")
-	@DeleteMapping(value = "/delete/{replyId}", produces = "application/json")
+	@DeleteMapping(value = "/delete/{replyId}")
 	public void deleteReply(@PathVariable Long replyId) {
 		replyWriteService.deleteReply(replyId);
 	}
 
 	@Operation(summary = "댓글 좋아요", description = "댓글 좋아요를 한다")
-	@PutMapping(value = "/like/{replyId}", produces = "application/json")
+	@PutMapping(value = "/like/{replyId}")
 	public void likeReply(@PathVariable Long replyId) {
 		replyWriteService.likeReply(replyId);
 	}

--- a/src/main/java/toy/com/post/domain/Post.java
+++ b/src/main/java/toy/com/post/domain/Post.java
@@ -33,10 +33,10 @@ import toy.com.post.dto.request.PostModifyRequest;
 import toy.com.user.domain.User;
 
 @Entity
-@ToString
 @Getter
 @DynamicInsert
 @DynamicUpdate
+@ToString(exclude = {"replies", "postAdditionalList", "postWriter"})
 @EqualsAndHashCode(of = "id", callSuper = false)
 @Table(name = "post")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)

--- a/src/main/java/toy/com/post/domain/PostAdditional.java
+++ b/src/main/java/toy/com/post/domain/PostAdditional.java
@@ -23,7 +23,7 @@ import toy.com.user.domain.User;
 
 @Entity
 @Getter
-@ToString
+@ToString(exclude = {"reactionLikePostUser", "reactionPost"})
 @DynamicUpdate
 @EqualsAndHashCode(of = "id", callSuper = false)
 @Table(name = "post_additional")

--- a/src/main/java/toy/com/post/domain/Reply.java
+++ b/src/main/java/toy/com/post/domain/Reply.java
@@ -37,7 +37,7 @@ import toy.com.user.domain.User;
 @Getter
 @DynamicUpdate
 @DynamicInsert
-@ToString(exclude = "post")
+@ToString(exclude = {"post", "replyWriter", "replyAdditionalList"})
 @EqualsAndHashCode(of = "id", callSuper = false)
 @Table(name = "reply")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)

--- a/src/main/java/toy/com/post/domain/ReplyAdditional.java
+++ b/src/main/java/toy/com/post/domain/ReplyAdditional.java
@@ -23,7 +23,7 @@ import toy.com.user.domain.User;
 
 @Entity
 @Getter
-@ToString
+@ToString(exclude = {"reactionLikeReplyUser", "reactionReply"})
 @EqualsAndHashCode(of = "id", callSuper = false)
 @Table(name = "reply_additional")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)

--- a/src/main/java/toy/com/post/dto/request/PostCreateRequest.java
+++ b/src/main/java/toy/com/post/dto/request/PostCreateRequest.java
@@ -3,8 +3,10 @@ package toy.com.post.dto.request;
 import javax.validation.constraints.NotBlank;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
 import toy.com.post.domain.PostCategory;
 
+@Builder
 public record PostCreateRequest(@Schema(description = "게시글 제목")
 								@NotBlank(message = "제목을 작성해 주세요")
 								String title,

--- a/src/main/java/toy/com/post/dto/request/PostModifyRequest.java
+++ b/src/main/java/toy/com/post/dto/request/PostModifyRequest.java
@@ -3,8 +3,10 @@ package toy.com.post.dto.request;
 import javax.validation.constraints.NotBlank;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
 import toy.com.post.domain.PostCategory;
 
+@Builder
 public record PostModifyRequest(@NotBlank(message = "수정하려는 게시글 번호는 비어있을 수 없습니다")
 								@Schema(description = "게시글 번호")
 								Long postId,

--- a/src/main/java/toy/com/post/dto/request/ReplyCreateRequest.java
+++ b/src/main/java/toy/com/post/dto/request/ReplyCreateRequest.java
@@ -3,7 +3,9 @@ package toy.com.post.dto.request;
 import javax.validation.constraints.NotBlank;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
 
+@Builder
 public record ReplyCreateRequest(@NotBlank(message = "게시글 아이디가 없습니다")
 								 @Schema(description = "댓글이 작성될 게시글번호")
 								 Long postId,

--- a/src/main/java/toy/com/post/dto/request/ReplyModifyRequest.java
+++ b/src/main/java/toy/com/post/dto/request/ReplyModifyRequest.java
@@ -3,7 +3,9 @@ package toy.com.post.dto.request;
 import javax.validation.constraints.NotBlank;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
 
+@Builder
 public record ReplyModifyRequest(@NotBlank(message = "수정할 댓글 아이디가 없습니다")
 								 @Schema(description = "수정할 댓글 아이디")
 								 Long replyId,

--- a/src/main/java/toy/com/post/service/PostWriteService.java
+++ b/src/main/java/toy/com/post/service/PostWriteService.java
@@ -86,6 +86,7 @@ public class PostWriteService {
 
 	@Transactional(propagation = Propagation.REQUIRES_NEW)
 	public void updatePostViewCount(Long postId) {
+
 		Post updatePost = findPostByPostId(postId);
 		updatePost.updateViewCount();
 	}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -3,7 +3,6 @@
 spring:
   jackson:
     default-property-inclusion: non_null
-    property-naming-strategy: SNAKE_CASE
     serialization:
       fail-on-empty-beans: false
   datasource:

--- a/src/test/java/toy/com/post/controller/PostControllerTest.java
+++ b/src/test/java/toy/com/post/controller/PostControllerTest.java
@@ -1,0 +1,191 @@
+package toy.com.post.controller;
+
+import static org.springframework.http.MediaType.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.web.PageableHandlerMethodArgumentResolver;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import toy.com.post.domain.Post;
+import toy.com.post.domain.PostCategory;
+import toy.com.post.domain.PostStatus;
+import toy.com.post.dto.request.PostCreateRequest;
+import toy.com.post.dto.request.PostModifyRequest;
+import toy.com.post.dto.response.PostDetailInfoResponse;
+import toy.com.post.repository.PostRepository;
+import toy.com.post.service.PostReadService;
+import toy.com.post.service.PostWriteService;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class PostControllerTest {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Autowired
+	private ObjectMapper objectMapper;
+
+	@Autowired
+	private PostReadService postReadService;
+
+	@Autowired
+	private PostWriteService postWriteService;
+
+	@Autowired
+	private PostRepository postRepository;
+
+	@BeforeEach
+	void setup() {
+
+		postRepository.deleteAll();
+
+		this.mockMvc = MockMvcBuilders.standaloneSetup(new PostController(postReadService, postWriteService))
+			.setCustomArgumentResolvers(new PageableHandlerMethodArgumentResolver())
+			.build();
+	}
+
+	@Test
+	@DisplayName("게시글 작성 테스트")
+	void createPost() throws Exception {
+
+		PostCreateRequest request = PostCreateRequest.builder()
+			.title("테스트")
+			.content("테스트")
+			.category(PostCategory.DEFAULT)
+			.build();
+
+		mockMvc.perform(post("/api/post/write")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(request)))
+			.andExpect(status().isCreated())
+			.andDo(print());
+	}
+
+	@Test
+	@DisplayName("게시글 수정 테스트")
+	void modifyPost() throws Exception {
+
+		Post createPost = Post.builder()
+			.postTitle("테스트111")
+			.postContent("테스트")
+			.postCategory(PostCategory.DEFAULT)
+			.postStatus(PostStatus.NORMAL)
+			.build();
+
+		postRepository.save(createPost);
+
+		PostModifyRequest request = PostModifyRequest.builder()
+			.postId(createPost.getId())
+			.title("수정테스트")
+			.content("테스트")
+			.category(PostCategory.DEFAULT)
+			.build();
+
+		mockMvc.perform(patch("/api/post/modify")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(request)))
+			.andExpect(status().isOk())
+			.andDo(print());
+	}
+
+	@Test
+	@DisplayName("게시글 삭제 테스트")
+	void deletePost() throws Exception {
+
+		Post createPost = Post.builder()
+			.postTitle("테스트111")
+			.postContent("테스트")
+			.postCategory(PostCategory.DEFAULT)
+			.postStatus(PostStatus.NORMAL)
+			.build();
+
+		postRepository.save(createPost);
+
+		mockMvc.perform(delete("/api/post/delete/{postId}", createPost.getId()))
+			.andExpect(status().isOk())
+			.andDo(print());
+	}
+
+	@Test
+	@DisplayName("게시글 리스트 조회 테스트")
+	void getPostList() throws Exception {
+
+		int page = 0;
+
+		PostCreateRequest request = PostCreateRequest.builder()
+			.title("테스트")
+			.content("테스트")
+			.category(PostCategory.DEFAULT)
+			.build();
+
+		postWriteService.createPost(request);
+
+		mockMvc.perform(get("/api/post/list")
+				.contentType("application/x-www-form-urlencoded")
+				.param("page", String.valueOf(page)))
+			.andExpect(status().isOk())
+			.andDo(print());
+	}
+
+	@Test
+	@DisplayName("게시글 상세 조회 테스트")
+	void getPostDetail() throws Exception {
+
+		PostCreateRequest request = PostCreateRequest.builder()
+			.title("테스트")
+			.content("테스트")
+			.category(PostCategory.DEFAULT)
+			.build();
+
+		postWriteService.createPost(request);
+
+		Post post = postRepository.findAll().get(0);
+
+		PostDetailInfoResponse res = postReadService.getPostDetail(post.getId());
+
+		mockMvc.perform(get("/api/post/detail/{postId}", post.getId())
+				.contentType(APPLICATION_JSON))
+			.andExpect(jsonPath("postId").value(res.postId()))
+			.andExpect(jsonPath("title").value(res.title()))
+			.andExpect(jsonPath("userId").value(res.userId()))
+			.andExpect(jsonPath("userName").value(res.userName()))
+			.andExpect(jsonPath("category").value(res.category()))
+			.andExpect(jsonPath("likeCounts").value(res.likeCounts()))
+			.andExpect(jsonPath("viewCounts").value(res.viewCounts() + 1))
+			.andExpect(jsonPath("postMyReaction").value(res.postMyReaction()))
+			.andExpect(status().isOk())
+			.andDo(print());
+	}
+
+	@Test
+	@DisplayName("게시글 좋아요 테스트")
+	void postLike() throws Exception {
+
+		PostCreateRequest request = PostCreateRequest.builder()
+			.title("테스트")
+			.content("테스트")
+			.category(PostCategory.DEFAULT)
+			.build();
+
+		postWriteService.createPost(request);
+
+		Post post = postRepository.findAll().get(0);
+
+		mockMvc.perform(put("/api/post/like/{postId}", post.getId()))
+			.andExpect(status().isOk())
+			.andDo(print());
+	}
+}

--- a/src/test/java/toy/com/post/controller/PostControllerTest.java
+++ b/src/test/java/toy/com/post/controller/PostControllerTest.java
@@ -25,8 +25,8 @@ import toy.com.post.dto.request.PostCreateRequest;
 import toy.com.post.dto.request.PostModifyRequest;
 import toy.com.post.dto.response.PostDetailInfoResponse;
 import toy.com.post.repository.PostRepository;
-import toy.com.post.service.PostReadService;
-import toy.com.post.service.PostWriteService;
+import toy.com.post.service.PostCommandService;
+import toy.com.post.service.PostQueryService;
 
 @SpringBootTest
 @AutoConfigureMockMvc
@@ -39,10 +39,10 @@ class PostControllerTest {
 	private ObjectMapper objectMapper;
 
 	@Autowired
-	private PostReadService postReadService;
+	private PostQueryService postQueryService;
 
 	@Autowired
-	private PostWriteService postWriteService;
+	private PostCommandService postCommandService;
 
 	@Autowired
 	private PostRepository postRepository;
@@ -52,7 +52,7 @@ class PostControllerTest {
 
 		postRepository.deleteAll();
 
-		this.mockMvc = MockMvcBuilders.standaloneSetup(new PostController(postReadService, postWriteService))
+		this.mockMvc = MockMvcBuilders.standaloneSetup(new PostController(postQueryService, postCommandService))
 			.setCustomArgumentResolvers(new PageableHandlerMethodArgumentResolver())
 			.build();
 	}
@@ -131,7 +131,7 @@ class PostControllerTest {
 			.category(PostCategory.DEFAULT)
 			.build();
 
-		postWriteService.createPost(request);
+		postCommandService.createPost(request);
 
 		mockMvc.perform(get("/api/post/list")
 				.contentType("application/x-www-form-urlencoded")
@@ -150,11 +150,11 @@ class PostControllerTest {
 			.category(PostCategory.DEFAULT)
 			.build();
 
-		postWriteService.createPost(request);
+		postCommandService.createPost(request);
 
 		Post post = postRepository.findAll().get(0);
 
-		PostDetailInfoResponse res = postReadService.getPostDetail(post.getId());
+		PostDetailInfoResponse res = postQueryService.getPostDetail(post.getId());
 
 		mockMvc.perform(get("/api/post/detail/{postId}", post.getId())
 				.contentType(APPLICATION_JSON))
@@ -180,7 +180,7 @@ class PostControllerTest {
 			.category(PostCategory.DEFAULT)
 			.build();
 
-		postWriteService.createPost(request);
+		postCommandService.createPost(request);
 
 		Post post = postRepository.findAll().get(0);
 

--- a/src/test/java/toy/com/post/controller/ReplyControllerTest.java
+++ b/src/test/java/toy/com/post/controller/ReplyControllerTest.java
@@ -1,0 +1,174 @@
+package toy.com.post.controller;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import toy.com.post.domain.Post;
+import toy.com.post.domain.PostCategory;
+import toy.com.post.domain.Reply;
+import toy.com.post.dto.request.PostCreateRequest;
+import toy.com.post.dto.request.ReplyCreateRequest;
+import toy.com.post.dto.request.ReplyModifyRequest;
+import toy.com.post.repository.PostRepository;
+import toy.com.post.repository.ReplyRepository;
+import toy.com.post.service.PostWriteService;
+import toy.com.post.service.ReplyWriteService;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class ReplyControllerTest {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Autowired
+	private ObjectMapper objectMapper;
+
+	@Autowired
+	private ReplyWriteService replyWriteService;
+
+	@Autowired
+	private PostWriteService postWriteService;
+
+	@Autowired
+	private PostRepository postRepository;
+
+	@Autowired
+	private ReplyRepository replyRepository;
+
+	@BeforeEach
+	void setup() {
+		postRepository.deleteAll();
+		replyRepository.deleteAll();
+	}
+
+	@Test
+	@DisplayName("댓글 작성 테스트")
+	void createReply() throws Exception {
+
+		PostCreateRequest request = PostCreateRequest.builder()
+			.title("테스트")
+			.content("테스트")
+			.category(PostCategory.DEFAULT)
+			.build();
+
+		postWriteService.createPost(request);
+
+		Post post = postRepository.findAll().get(0);
+
+		ReplyCreateRequest replyCreateRequest = ReplyCreateRequest.builder()
+			.postId(post.getId())
+			.content("테스트")
+			.build();
+
+		mockMvc.perform(post("/api/reply/write")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(replyCreateRequest)))
+			.andExpect(status().isCreated())
+			.andDo(print());
+	}
+
+	@Test
+	@DisplayName("댓글 수정 테스트")
+	void modifyReply() throws Exception {
+
+		PostCreateRequest request = PostCreateRequest.builder()
+			.title("테스트")
+			.content("테스트")
+			.category(PostCategory.DEFAULT)
+			.build();
+
+		postWriteService.createPost(request);
+
+		Post post = postRepository.findAll().get(0);
+
+		ReplyCreateRequest replyCreateRequest = ReplyCreateRequest.builder()
+			.postId(post.getId())
+			.content("테스트")
+			.build();
+
+		replyWriteService.createReply(replyCreateRequest);
+
+		Reply reply = replyRepository.findAll().get(0);
+
+		ReplyModifyRequest modifyRequest = ReplyModifyRequest.builder()
+			.replyId(reply.getId())
+			.content("수정테스트")
+			.build();
+
+		mockMvc.perform(patch("/api/reply/modify")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(modifyRequest)))
+			.andExpect(status().isOk())
+			.andDo(print());
+	}
+
+	@Test
+	@DisplayName("댓글 삭제 테스트")
+	void deleteReply() throws Exception {
+
+		PostCreateRequest request = PostCreateRequest.builder()
+			.title("테스트")
+			.content("테스트")
+			.category(PostCategory.DEFAULT)
+			.build();
+
+		postWriteService.createPost(request);
+
+		Post post = postRepository.findAll().get(0);
+
+		ReplyCreateRequest replyCreateRequest = ReplyCreateRequest.builder()
+			.postId(post.getId())
+			.content("테스트")
+			.build();
+
+		replyWriteService.createReply(replyCreateRequest);
+
+		Reply reply = replyRepository.findAll().get(0);
+
+		mockMvc.perform(delete("/api/reply/delete/{replyId}", reply.getId()))
+			.andExpect(status().isOk())
+			.andDo(print());
+	}
+
+	@Test
+	@DisplayName("댓글 좋아요 테스트")
+	void likeReply() throws Exception {
+
+		PostCreateRequest request = PostCreateRequest.builder()
+			.title("테스트")
+			.content("테스트")
+			.category(PostCategory.DEFAULT)
+			.build();
+
+		postWriteService.createPost(request);
+
+		Post post = postRepository.findAll().get(0);
+
+		ReplyCreateRequest replyCreateRequest = ReplyCreateRequest.builder()
+			.postId(post.getId())
+			.content("테스트")
+			.build();
+
+		replyWriteService.createReply(replyCreateRequest);
+
+		Reply reply = replyRepository.findAll().get(0);
+
+		mockMvc.perform(put("/api/reply/like/{replyId}", reply.getId()))
+			.andExpect(status().isOk())
+			.andDo(print());
+	}
+
+}

--- a/src/test/java/toy/com/post/service/PostReadServiceTest.java
+++ b/src/test/java/toy/com/post/service/PostReadServiceTest.java
@@ -1,9 +1,10 @@
 package toy.com.post.service;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.*;
 
 import java.util.ArrayList;
 import java.util.List;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -14,6 +15,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.transaction.annotation.Transactional;
+
 import toy.com.post.domain.Post;
 import toy.com.post.domain.PostCategory;
 import toy.com.post.domain.PostStatus;
@@ -28,82 +30,81 @@ import toy.com.user.repository.UserRepository;
 @Transactional
 class PostReadServiceTest {
 
-    private static final int PAGE_SIZE = 20;
+	private static final int PAGE_SIZE = 20;
 
-    @Autowired
-    private PostReadService postReadService;
+	@Autowired
+	private PostReadService postReadService;
 
-    @Autowired
-    private PostRepository postRepository;
+	@Autowired
+	private PostRepository postRepository;
 
-    @Autowired
-    private UserRepository userRepository;
+	@Autowired
+	private UserRepository userRepository;
 
-    @BeforeEach
-    void setUp() {
+	@BeforeEach
+	void setUp() {
 
-        List<Post> bulkInsert = new ArrayList<>();
+		List<Post> bulkInsert = new ArrayList<>();
 
-        User samplePostWriterUser = User.builder()
-            .email("useremail1@naver.com")
-            .password("xzcjzkxcjxz1212")
-            .nickname("닉네임11111")
-            .build();
+		User samplePostWriterUser = User.builder()
+			.email("useremail1@naver.com")
+			.password("xzcjzkxcjxz1212")
+			.nickname("닉네임11111")
+			.build();
 
-        User sampleReplyWriterUser = User.builder()
-            .email("useremail2@naver.com")
-            .password("xzcjzkxcjxz1212")
-            .nickname("닉네임22222")
-            .build();
+		User sampleReplyWriterUser = User.builder()
+			.email("useremail2@naver.com")
+			.password("xzcjzkxcjxz1212")
+			.nickname("닉네임22222")
+			.build();
 
-        for (int i = 0; i < 100; i ++) {
-            Reply sampleReply = Reply.builder()
-                .content("샘플 답글")
-                .replyLikes(1)
-                .replyWriter(sampleReplyWriterUser)
-                .build();
+		for (int i = 0; i < 100; i++) {
+			Reply sampleReply = Reply.builder()
+				.content("샘플 답글")
+				.replyLikes(1)
+				.replyWriter(sampleReplyWriterUser)
+				.build();
 
-            Post samplePost = Post.builder()
-                .postTitle("샘플 포스트")
-                .postContent("샘플내용")
-                .postStatus(PostStatus.NORMAL)
-                .postCategory(PostCategory.DEFAULT)
-                .postWriter(samplePostWriterUser)
-                .reply(sampleReply)
-                .build();
+			Post samplePost = Post.builder()
+				.postTitle("샘플 포스트")
+				.postContent("샘플내용")
+				.postStatus(PostStatus.NORMAL)
+				.postCategory(PostCategory.DEFAULT)
+				.postWriter(samplePostWriterUser)
+				.build();
 
-            sampleReply.applyPost(samplePost);
+			sampleReply.applyPost(samplePost);
 
-            bulkInsert.add(samplePost);
-        }
+			bulkInsert.add(samplePost);
+		}
 
-        userRepository.save(samplePostWriterUser);
-        userRepository.save(sampleReplyWriterUser);
+		userRepository.save(samplePostWriterUser);
+		userRepository.save(sampleReplyWriterUser);
 
-        postRepository.saveAll(bulkInsert);
-    }
+		postRepository.saveAll(bulkInsert);
+	}
 
-    @ParameterizedTest
-    @ValueSource(ints = {1, 2, 3, 4})
-    @DisplayName("게시글이 페이지 네이션 개수만큼 갖고와지는지 확인")
-    void getPostList(int page) {
+	@ParameterizedTest
+	@ValueSource(ints = {1, 2, 3, 4})
+	@DisplayName("게시글이 페이지 네이션 개수만큼 갖고와지는지 확인")
+	void getPostList(int page) {
 
-        Pageable pageable = PageRequest.of(page, PAGE_SIZE);
+		Pageable pageable = PageRequest.of(page, PAGE_SIZE);
 
-        PostListsResponse response = postReadService.getPostListPerPage(pageable);
+		PostListsResponse response = postReadService.getPostListPerPage(pageable);
 
-        assertThat(response.postResults().size()).isEqualTo(PAGE_SIZE);
-    }
+		assertThat(response.postResults().size()).isEqualTo(PAGE_SIZE);
+	}
 
-    @Test
-    @DisplayName("게시글 상세 내용 조회시 답글이 있는 경우 답글이 같이 내려오는지 확인")
-    void getPostDetail() {
+	@Test
+	@DisplayName("게시글 상세 내용 조회시 답글이 있는 경우 답글이 같이 내려오는지 확인")
+	void getPostDetail() {
 
-        Long samplePostId = 1L;
+		Long samplePostId = 1L;
 
-        PostDetailInfoResponse infoResponse = postReadService.getPostDetail(samplePostId);
+		PostDetailInfoResponse infoResponse = postReadService.getPostDetail(samplePostId);
 
-        System.out.println(infoResponse);
-    }
+		System.out.println(infoResponse);
+	}
 
 }


### PR DESCRIPTION
## 작업에 대한 간단한 요약
게시글, 댓글에 대한 컨트롤러 테스트를 추가하였습니다.


### 변경내역
- 컨트롤러 테스트 추가
- swagger 응답객체 없을시 produces 부분 제거
- 연관관계 맵핑 후 toString 무한 참조 발생 방지 위해 연관관계 객체에 예외처리 추가 


### 어떤부분에 집중해서 리뷰하면좋을지
- 없음


### 이슈번호 외 기타내용
