### PR TITLE
feat: embedded redis - #14

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -46,6 +46,9 @@ dependencies {
     // Bcrypt 암호화
     implementation group: 'org.mindrot', name: 'jbcrypt', version: '0.4'
 
+    // 내장 redis
+    implementation 'it.ozimov:embedded-redis:0.7.2'
+
     // swagger open Api
     implementation 'org.springdoc:springdoc-openapi-ui:1.5.7'
 
@@ -56,10 +59,6 @@ dependencies {
 
     // open Api class path 설정을 위한 의존성 추가
     implementation group: 'io.github.classgraph', name: 'classgraph', version: '4.8.126'
-
-    //Slf4j
-    implementation group: 'org.slf4j', name: 'slf4j-api', version: '1.7.25'
-
 }
 
 tasks.named('test') {

--- a/src/main/java/toy/com/config/EmbeddedRedis.java
+++ b/src/main/java/toy/com/config/EmbeddedRedis.java
@@ -1,0 +1,41 @@
+package toy.com.config;
+
+import javax.annotation.PostConstruct;
+import javax.annotation.PreDestroy;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+
+import redis.embedded.RedisServer;
+
+@Profile("local")
+@Configuration
+public class EmbeddedRedis {
+
+	private final int redisPort;
+	private static RedisServer redisServer;
+
+	public EmbeddedRedis(@Value("${spring.redis.port}") final int redisPort) {
+		this.redisPort = redisPort;
+	}
+
+	@PostConstruct
+	public void redisServer() {
+		if (redisServer == null) {
+			redisServer = RedisServer.builder()
+				.port(redisPort)
+				.setting("maxmemory 128M")
+				.build();
+
+			redisServer.start();
+		}
+	}
+
+	@PreDestroy
+	public void stopRedis() {
+		if (redisServer != null) {
+			redisServer.stop();
+		}
+	}
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,4 +1,7 @@
 spring:
+  profiles:
+    default: local
+
   datasource:
     hikari:
       jdbc-url: jdbc:h2:mem:testdb:MODE=MYSQL


### PR DESCRIPTION
## 작업에 대한 간단한 요약
프론트엔드의 요청으로 redis서버를 따로 띄우지않고 테스트가 가능하게끔 하기위해 내장 레디스를 로컬에서만 작동하게끔 설정했다.

### 변경내역
- default profile을 "default" -> "local"로 변경했습니다 
- 내장 레디스 추가


### 어떤부분에 집중해서 리뷰하면좋을지


### 이슈번호 외 기타내용
#14 
