### PR TITLE
feature/#23 secretManager 연동, 메서드 이름 변경에 따른 테스트 메서드 수정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -60,6 +60,11 @@ dependencies {
     //Slf4j
     implementation group: 'org.slf4j', name: 'slf4j-api', version: '1.7.25'
 
+    // aws secret manager
+    implementation 'org.springframework.cloud:spring-cloud-starter-bootstrap:3.1.3'
+    implementation 'org.springframework.cloud:spring-cloud-starter-aws-secrets-manager-config:2.2.6.RELEASE'
+    implementation 'com.amazonaws.secretsmanager:aws-secretsmanager-jdbc:1.0.8'
+
 }
 
 tasks.named('test') {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -24,8 +24,9 @@ logging:
   level:
     org.hibernate.type: trace
 
+# 임시 주석 처리 추후 불필요시 제거
+#jwt:
+#  secret-key: ${JWT_SECRET_KEY}
+#  access-token-expired-time: ${JWT_ACCESSTOKEN_EXPIRED_TIME_MS}
+#  refresh-token-expired-time: ${JWT_REFRESHTOKEN_EXPIRED_TIME_MS}
 
-jwt:
-  secret-key: ${JWT_SECRET_KEY}
-  access-token-expired-time: ${JWT_ACCESSTOKEN_EXPIRED_TIME_MS}
-  refresh-token-expired-time: ${JWT_REFRESHTOKEN_EXPIRED_TIME_MS}

--- a/src/main/resources/bootstrap.yaml
+++ b/src/main/resources/bootstrap.yaml
@@ -1,7 +1,7 @@
 aws:
   secretsmanager:
-    name: jwt
-    prefix: /secret
+    name: shinity
+    prefix: /secrets
 
 cloud:
   aws:

--- a/src/main/resources/bootstrap.yaml
+++ b/src/main/resources/bootstrap.yaml
@@ -1,0 +1,9 @@
+aws:
+  secretsmanager:
+    name: jwt
+    prefix: /secret
+
+cloud:
+  aws:
+    region:
+      static: ap-northeast-2

--- a/src/test/java/toy/com/config/AwsSecretManagerTest.java
+++ b/src/test/java/toy/com/config/AwsSecretManagerTest.java
@@ -1,0 +1,27 @@
+package toy.com.config;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+public class AwsSecretManagerTest {
+
+	@Value("${jwt.access-token-expired-time}")
+	private String accessExpiredTime;
+
+	@Value("${jwt.refresh-token-expired-time}")
+	private String refreshExpiredTime;
+
+	@Test
+	@DisplayName("로컬에서 secretManager를 통해 값이 불러와 지는지 확인 ")
+	void secretKeyTest() {
+
+		assertThat(accessExpiredTime).isEqualTo("1800000");
+
+		assertThat(refreshExpiredTime).isEqualTo("604800000");
+	}
+}

--- a/src/test/java/toy/com/post/controller/ReplyControllerTest.java
+++ b/src/test/java/toy/com/post/controller/ReplyControllerTest.java
@@ -23,8 +23,8 @@ import toy.com.post.dto.request.ReplyCreateRequest;
 import toy.com.post.dto.request.ReplyModifyRequest;
 import toy.com.post.repository.PostRepository;
 import toy.com.post.repository.ReplyRepository;
-import toy.com.post.service.PostWriteService;
-import toy.com.post.service.ReplyWriteService;
+import toy.com.post.service.PostCommandService;
+import toy.com.post.service.ReplyCommandService;
 
 @SpringBootTest
 @AutoConfigureMockMvc
@@ -37,10 +37,10 @@ class ReplyControllerTest {
 	private ObjectMapper objectMapper;
 
 	@Autowired
-	private ReplyWriteService replyWriteService;
+	private ReplyCommandService replyCommandService;
 
 	@Autowired
-	private PostWriteService postWriteService;
+	private PostCommandService postCommandService;
 
 	@Autowired
 	private PostRepository postRepository;
@@ -64,7 +64,7 @@ class ReplyControllerTest {
 			.category(PostCategory.DEFAULT)
 			.build();
 
-		postWriteService.createPost(request);
+		postCommandService.createPost(request);
 
 		Post post = postRepository.findAll().get(0);
 
@@ -90,7 +90,7 @@ class ReplyControllerTest {
 			.category(PostCategory.DEFAULT)
 			.build();
 
-		postWriteService.createPost(request);
+		postCommandService.createPost(request);
 
 		Post post = postRepository.findAll().get(0);
 
@@ -99,7 +99,7 @@ class ReplyControllerTest {
 			.content("테스트")
 			.build();
 
-		replyWriteService.createReply(replyCreateRequest);
+		replyCommandService.createReply(replyCreateRequest);
 
 		Reply reply = replyRepository.findAll().get(0);
 
@@ -125,7 +125,7 @@ class ReplyControllerTest {
 			.category(PostCategory.DEFAULT)
 			.build();
 
-		postWriteService.createPost(request);
+		postCommandService.createPost(request);
 
 		Post post = postRepository.findAll().get(0);
 
@@ -134,7 +134,7 @@ class ReplyControllerTest {
 			.content("테스트")
 			.build();
 
-		replyWriteService.createReply(replyCreateRequest);
+		replyCommandService.createReply(replyCreateRequest);
 
 		Reply reply = replyRepository.findAll().get(0);
 
@@ -153,7 +153,7 @@ class ReplyControllerTest {
 			.category(PostCategory.DEFAULT)
 			.build();
 
-		postWriteService.createPost(request);
+		postCommandService.createPost(request);
 
 		Post post = postRepository.findAll().get(0);
 
@@ -162,7 +162,7 @@ class ReplyControllerTest {
 			.content("테스트")
 			.build();
 
-		replyWriteService.createReply(replyCreateRequest);
+		replyCommandService.createReply(replyCreateRequest);
 
 		Reply reply = replyRepository.findAll().get(0);
 

--- a/src/test/java/toy/com/post/service/PostReadServiceTest.java
+++ b/src/test/java/toy/com/post/service/PostReadServiceTest.java
@@ -33,7 +33,7 @@ class PostReadServiceTest {
 	private static final int PAGE_SIZE = 20;
 
 	@Autowired
-	private PostReadService postReadService;
+	private PostQueryService postQueryService;
 
 	@Autowired
 	private PostRepository postRepository;
@@ -91,7 +91,7 @@ class PostReadServiceTest {
 
 		Pageable pageable = PageRequest.of(page, PAGE_SIZE);
 
-		PostListsResponse response = postReadService.getPostListPerPage(pageable);
+		PostListsResponse response = postQueryService.getPostListPerPage(pageable);
 
 		assertThat(response.postResults().size()).isEqualTo(PAGE_SIZE);
 	}
@@ -102,7 +102,7 @@ class PostReadServiceTest {
 
 		Long samplePostId = 1L;
 
-		PostDetailInfoResponse infoResponse = postReadService.getPostDetail(samplePostId);
+		PostDetailInfoResponse infoResponse = postQueryService.getPostDetail(samplePostId);
 
 		System.out.println(infoResponse);
 	}


### PR DESCRIPTION
## 작업에 대한 간단한 요약

jwt 값 갖고 오는 부분을 AWS secretmanager 와 연동하였습니다.


### 변경내역
- yml 에 정의된 Jwt 값 대신 secretmanger를 통해 주입바도록 변경


### 어떤부분에 집중해서 리뷰하면좋을지


### 이슈번호 외 기타내용

로컬 application에서 접근시 accesskey와 secretKey가 필요함으로 해당 값은 추후 알려드리겠습니다 
