### PR TITLE
feature/#34 댓글, 글쓰기 좋아요/취소 엔드포인트 분리 구현

### DIFF
--- a/src/main/java/toy/com/post/controller/PostController.java
+++ b/src/main/java/toy/com/post/controller/PostController.java
@@ -7,7 +7,6 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseStatus;
@@ -65,9 +64,15 @@ public class PostController {
 	}
 
 	@Operation(summary = "게시글 좋아요", description = "게시글 좋아요를 한다")
-	@PutMapping(value = "/like/{postId}")
+	@PostMapping(value = "/like/{postId}")
 	public void likePost(@PathVariable Long postId) {
-		postCommandService.updateLikePost(postId);
+		postCommandService.likePost(postId);
+	}
+
+	@Operation(summary = "게시글 좋아요 취소", description = "게시글 좋아요를 취소 한다")
+	@DeleteMapping(value = "/like/{postId}")
+	public void dislikePost(@PathVariable Long postId) {
+		postCommandService.disLikePost(postId);
 	}
 
 }

--- a/src/main/java/toy/com/post/controller/ReplyController.java
+++ b/src/main/java/toy/com/post/controller/ReplyController.java
@@ -5,7 +5,6 @@ import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseStatus;
@@ -46,8 +45,14 @@ public class ReplyController {
 	}
 
 	@Operation(summary = "댓글 좋아요", description = "댓글 좋아요를 한다")
-	@PutMapping("/like/{replyId}")
+	@PostMapping("/like/{replyId}")
 	public void likeReply(@PathVariable Long replyId) {
 		replyCommandService.likeReply(replyId);
+	}
+
+	@Operation(summary = "댓글 좋아요 취소", description = "댓글 좋아요를 취소 한다")
+	@DeleteMapping("/like/{replyId}")
+	public void disLikeReply(@PathVariable Long replyId) {
+		replyCommandService.disLikeReply(replyId);
 	}
 }

--- a/src/main/java/toy/com/post/domain/Post.java
+++ b/src/main/java/toy/com/post/domain/Post.java
@@ -112,8 +112,12 @@ public class Post extends BaseTimeEntity {
 		this.viewCounts += 1;
 	}
 
-	public void updatePostLikeCount() {
+	public void plusPostLikeCount() {
 		this.likeCounts += 1;
+	}
+
+	public void minusPostLikeCount() {
+		this.likeCounts -= 1;
 	}
 
 	public void deletePost() {

--- a/src/main/java/toy/com/post/domain/Reply.java
+++ b/src/main/java/toy/com/post/domain/Reply.java
@@ -101,8 +101,12 @@ public class Reply extends BaseTimeEntity {
 		this.replyStatus = ReplyStatus.DELETED;
 	}
 
-	public void updateReplyLike() {
+	public void plusReplyLikeCount() {
 		this.replyLikes += 1;
+	}
+
+	public void minusReplyLikeCount() {
+		this.replyLikes -= 1;
 	}
 
 }

--- a/src/main/java/toy/com/post/repository/ReplyAdditionalRepository.java
+++ b/src/main/java/toy/com/post/repository/ReplyAdditionalRepository.java
@@ -5,4 +5,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import toy.com.post.domain.ReplyAdditional;
 
 public interface ReplyAdditionalRepository extends JpaRepository<ReplyAdditional, Long> {
+	void deleteByReactionReplyId(Long replyId);
 }

--- a/src/main/java/toy/com/post/service/PostCommandService.java
+++ b/src/main/java/toy/com/post/service/PostCommandService.java
@@ -63,7 +63,7 @@ public class PostCommandService {
 		post.deletePost();
 	}
 
-	public void updateLikePost(Long postId) {
+	public void likePost(Long postId) {
 
 		// TODO(박종빈) 추후 유저 벧리데이션으로 유저값 갖고옴
 		// 테스트를 위한 셈플
@@ -74,14 +74,22 @@ public class PostCommandService {
 			.build();
 
 		Post likePost = findPostByPostId(postId);
-		likePost.updatePostLikeCount();
+		likePost.plusPostLikeCount();
 
 		postRepository.save(likePost);
-
 		postAdditionalRepository.save(PostAdditional.builder()
 			.reactionPost(likePost)
 			.reactionPostUser(sampleUser)
 			.build());
+	}
+
+	public void disLikePost(Long postId) {
+
+		Post disLikePost = findPostByPostId(postId);
+		disLikePost.minusPostLikeCount();
+
+		postRepository.save(disLikePost);
+		postAdditionalRepository.deleteAll(disLikePost.getPostAdditionalList());
 	}
 
 	public void updatePostViewCount(Long postId) {

--- a/src/main/java/toy/com/post/service/PostQueryService.java
+++ b/src/main/java/toy/com/post/service/PostQueryService.java
@@ -31,13 +31,14 @@ public class PostQueryService {
 	public PostListsResponse getPostListPerPage(Pageable page) {
 
 		int totalPosts = postRepository.countBy();
+		int totalPages = (int)Math.ceil((double)totalPosts / DEFAULT_PAGE_COUNT);
 
 		return PostListsResponse.builder()
 			.postResults(getPostPerPage(page))
 			.page(page.getPageNumber())
 			.perCounts(getPostPerPage(page).size())
 			.totalPosts(totalPosts)
-			.totalPages(totalPosts / DEFAULT_PAGE_COUNT)
+			.totalPages(totalPages < 0 ? 1 : totalPages)
 			.build();
 	}
 

--- a/src/main/java/toy/com/post/service/ReplyCommandService.java
+++ b/src/main/java/toy/com/post/service/ReplyCommandService.java
@@ -72,13 +72,22 @@ public class ReplyCommandService {
 
 		Reply reply = findReplyByReplyId(replyId);
 
-		reply.updateReplyLike();
+		reply.plusReplyLikeCount();
 		replyRepository.save(reply);
 
 		replyAdditionalRepository.save(ReplyAdditional.builder()
 			.reactionReply(reply)
 			.likeUser(reactionReplyUser)
 			.build());
+	}
+
+	public void disLikeReply(Long replyId) {
+
+		Reply disLikeReply = findReplyByReplyId(replyId);
+
+		disLikeReply.minusReplyLikeCount();
+		replyRepository.save(disLikeReply);
+		replyAdditionalRepository.deleteByReactionReplyId(replyId);
 	}
 
 	public Reply findReplyByReplyId(Long replyId) {

--- a/src/test/java/toy/com/post/controller/PostControllerTest.java
+++ b/src/test/java/toy/com/post/controller/PostControllerTest.java
@@ -64,10 +64,9 @@ class PostControllerTest {
 		PostCreateRequest request = PostCreateRequest.builder()
 			.title("테스트")
 			.content("테스트")
-			.category(PostCategory.DEFAULT)
 			.build();
 
-		mockMvc.perform(post("/api/post/write")
+		mockMvc.perform(post("/api/posts")
 				.contentType(MediaType.APPLICATION_JSON)
 				.content(objectMapper.writeValueAsString(request)))
 			.andExpect(status().isCreated())
@@ -94,7 +93,7 @@ class PostControllerTest {
 			.category(PostCategory.DEFAULT)
 			.build();
 
-		mockMvc.perform(patch("/api/post/modify")
+		mockMvc.perform(patch("/api/posts")
 				.contentType(MediaType.APPLICATION_JSON)
 				.content(objectMapper.writeValueAsString(request)))
 			.andExpect(status().isOk())
@@ -114,7 +113,7 @@ class PostControllerTest {
 
 		postRepository.save(createPost);
 
-		mockMvc.perform(delete("/api/post/delete/{postId}", createPost.getId()))
+		mockMvc.perform(delete("/api/posts/{postId}", createPost.getId()))
 			.andExpect(status().isOk())
 			.andDo(print());
 	}
@@ -128,12 +127,11 @@ class PostControllerTest {
 		PostCreateRequest request = PostCreateRequest.builder()
 			.title("테스트")
 			.content("테스트")
-			.category(PostCategory.DEFAULT)
 			.build();
 
 		postCommandService.createPost(request);
 
-		mockMvc.perform(get("/api/post/list")
+		mockMvc.perform(get("/api/posts/list")
 				.contentType("application/x-www-form-urlencoded")
 				.param("page", String.valueOf(page)))
 			.andExpect(status().isOk())
@@ -147,7 +145,6 @@ class PostControllerTest {
 		PostCreateRequest request = PostCreateRequest.builder()
 			.title("테스트")
 			.content("테스트")
-			.category(PostCategory.DEFAULT)
 			.build();
 
 		postCommandService.createPost(request);
@@ -156,12 +153,12 @@ class PostControllerTest {
 
 		PostDetailInfoResponse res = postQueryService.getPostDetail(post.getId());
 
-		mockMvc.perform(get("/api/post/detail/{postId}", post.getId())
+		mockMvc.perform(get("/api/posts/detail/{postId}", post.getId())
 				.contentType(APPLICATION_JSON))
 			.andExpect(jsonPath("postId").value(res.postId()))
 			.andExpect(jsonPath("title").value(res.title()))
 			.andExpect(jsonPath("userId").value(res.userId()))
-			.andExpect(jsonPath("userName").value(res.userName()))
+			.andExpect(jsonPath("nickname").value(res.nickname()))
 			.andExpect(jsonPath("category").value(res.category()))
 			.andExpect(jsonPath("likeCounts").value(res.likeCounts()))
 			.andExpect(jsonPath("viewCounts").value(res.viewCounts() + 1))
@@ -177,14 +174,33 @@ class PostControllerTest {
 		PostCreateRequest request = PostCreateRequest.builder()
 			.title("테스트")
 			.content("테스트")
-			.category(PostCategory.DEFAULT)
 			.build();
 
 		postCommandService.createPost(request);
 
 		Post post = postRepository.findAll().get(0);
 
-		mockMvc.perform(put("/api/post/like/{postId}", post.getId()))
+		mockMvc.perform(post("/api/posts/like/{postId}", post.getId()))
+			.andExpect(status().isOk())
+			.andDo(print());
+	}
+
+	@Test
+	@DisplayName("게시글 좋아요 취소 테스트")
+	void postDisLike() throws Exception {
+
+		PostCreateRequest request = PostCreateRequest.builder()
+			.title("테스트")
+			.content("테스트")
+			.build();
+
+		postCommandService.createPost(request);
+
+		Post post = postRepository.findAll().get(0);
+
+		System.out.println(post.getId());
+
+		mockMvc.perform(delete("/api/posts/like/{postId}", post.getId()))
 			.andExpect(status().isOk())
 			.andDo(print());
 	}

--- a/src/test/java/toy/com/post/controller/ReplyControllerTest.java
+++ b/src/test/java/toy/com/post/controller/ReplyControllerTest.java
@@ -16,15 +16,14 @@ import org.springframework.test.web.servlet.MockMvc;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import toy.com.post.domain.Post;
-import toy.com.post.domain.PostCategory;
 import toy.com.post.domain.Reply;
 import toy.com.post.dto.request.PostCreateRequest;
 import toy.com.post.dto.request.ReplyCreateRequest;
 import toy.com.post.dto.request.ReplyModifyRequest;
 import toy.com.post.repository.PostRepository;
 import toy.com.post.repository.ReplyRepository;
-import toy.com.post.service.PostWriteService;
-import toy.com.post.service.ReplyWriteService;
+import toy.com.post.service.PostCommandService;
+import toy.com.post.service.ReplyCommandService;
 
 @SpringBootTest
 @AutoConfigureMockMvc
@@ -37,10 +36,10 @@ class ReplyControllerTest {
 	private ObjectMapper objectMapper;
 
 	@Autowired
-	private ReplyWriteService replyWriteService;
+	private ReplyCommandService replyCommandService;
 
 	@Autowired
-	private PostWriteService postWriteService;
+	private PostCommandService postCommandService;
 
 	@Autowired
 	private PostRepository postRepository;
@@ -61,10 +60,9 @@ class ReplyControllerTest {
 		PostCreateRequest request = PostCreateRequest.builder()
 			.title("테스트")
 			.content("테스트")
-			.category(PostCategory.DEFAULT)
 			.build();
 
-		postWriteService.createPost(request);
+		postCommandService.createPost(request);
 
 		Post post = postRepository.findAll().get(0);
 
@@ -73,7 +71,7 @@ class ReplyControllerTest {
 			.content("테스트")
 			.build();
 
-		mockMvc.perform(post("/api/reply/write")
+		mockMvc.perform(post("/api/reply")
 				.contentType(MediaType.APPLICATION_JSON)
 				.content(objectMapper.writeValueAsString(replyCreateRequest)))
 			.andExpect(status().isCreated())
@@ -87,10 +85,9 @@ class ReplyControllerTest {
 		PostCreateRequest request = PostCreateRequest.builder()
 			.title("테스트")
 			.content("테스트")
-			.category(PostCategory.DEFAULT)
 			.build();
 
-		postWriteService.createPost(request);
+		postCommandService.createPost(request);
 
 		Post post = postRepository.findAll().get(0);
 
@@ -99,7 +96,7 @@ class ReplyControllerTest {
 			.content("테스트")
 			.build();
 
-		replyWriteService.createReply(replyCreateRequest);
+		replyCommandService.createReply(replyCreateRequest);
 
 		Reply reply = replyRepository.findAll().get(0);
 
@@ -108,7 +105,7 @@ class ReplyControllerTest {
 			.content("수정테스트")
 			.build();
 
-		mockMvc.perform(patch("/api/reply/modify")
+		mockMvc.perform(patch("/api/reply")
 				.contentType(MediaType.APPLICATION_JSON)
 				.content(objectMapper.writeValueAsString(modifyRequest)))
 			.andExpect(status().isOk())
@@ -122,10 +119,9 @@ class ReplyControllerTest {
 		PostCreateRequest request = PostCreateRequest.builder()
 			.title("테스트")
 			.content("테스트")
-			.category(PostCategory.DEFAULT)
 			.build();
 
-		postWriteService.createPost(request);
+		postCommandService.createPost(request);
 
 		Post post = postRepository.findAll().get(0);
 
@@ -134,11 +130,11 @@ class ReplyControllerTest {
 			.content("테스트")
 			.build();
 
-		replyWriteService.createReply(replyCreateRequest);
+		replyCommandService.createReply(replyCreateRequest);
 
 		Reply reply = replyRepository.findAll().get(0);
 
-		mockMvc.perform(delete("/api/reply/delete/{replyId}", reply.getId()))
+		mockMvc.perform(delete("/api/reply/{replyId}", reply.getId()))
 			.andExpect(status().isOk())
 			.andDo(print());
 	}
@@ -150,10 +146,9 @@ class ReplyControllerTest {
 		PostCreateRequest request = PostCreateRequest.builder()
 			.title("테스트")
 			.content("테스트")
-			.category(PostCategory.DEFAULT)
 			.build();
 
-		postWriteService.createPost(request);
+		postCommandService.createPost(request);
 
 		Post post = postRepository.findAll().get(0);
 
@@ -162,11 +157,39 @@ class ReplyControllerTest {
 			.content("테스트")
 			.build();
 
-		replyWriteService.createReply(replyCreateRequest);
+		replyCommandService.createReply(replyCreateRequest);
 
 		Reply reply = replyRepository.findAll().get(0);
 
-		mockMvc.perform(put("/api/reply/like/{replyId}", reply.getId()))
+		mockMvc.perform(post("/api/reply/like/{replyId}", reply.getId()))
+			.andExpect(status().isOk())
+			.andDo(print());
+	}
+
+	@Test
+	@DisplayName("댓글 좋아요 취소 테스트")
+	void disLikeReply() throws Exception {
+
+		PostCreateRequest request = PostCreateRequest.builder()
+			.title("테스트")
+			.content("테스트")
+			.build();
+
+		postCommandService.createPost(request);
+
+		Post post = postRepository.findAll().get(0);
+
+		ReplyCreateRequest replyCreateRequest = ReplyCreateRequest.builder()
+			.postId(post.getId())
+			.content("테스트")
+			.build();
+
+		replyCommandService.createReply(replyCreateRequest);
+
+		Reply reply = replyRepository.findAll().get(0);
+		System.out.println(reply.getId());
+
+		mockMvc.perform(delete("/api/reply/like/{replyId}", reply.getId()))
 			.andExpect(status().isOk())
 			.andDo(print());
 	}

--- a/src/test/java/toy/com/post/service/PostReadServiceTest.java
+++ b/src/test/java/toy/com/post/service/PostReadServiceTest.java
@@ -7,7 +7,6 @@ import java.util.List;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -20,7 +19,6 @@ import toy.com.post.domain.Post;
 import toy.com.post.domain.PostCategory;
 import toy.com.post.domain.PostStatus;
 import toy.com.post.domain.Reply;
-import toy.com.post.dto.response.PostDetailInfoResponse;
 import toy.com.post.dto.response.PostListsResponse;
 import toy.com.post.repository.PostRepository;
 import toy.com.user.domain.User;
@@ -33,7 +31,7 @@ class PostReadServiceTest {
 	private static final int PAGE_SIZE = 20;
 
 	@Autowired
-	private PostReadService postReadService;
+	private PostQueryService postQueryService;
 
 	@Autowired
 	private PostRepository postRepository;
@@ -91,20 +89,9 @@ class PostReadServiceTest {
 
 		Pageable pageable = PageRequest.of(page, PAGE_SIZE);
 
-		PostListsResponse response = postReadService.getPostListPerPage(pageable);
+		PostListsResponse response = postQueryService.getPostListPerPage(pageable);
 
 		assertThat(response.postResults().size()).isEqualTo(PAGE_SIZE);
-	}
-
-	@Test
-	@DisplayName("게시글 상세 내용 조회시 답글이 있는 경우 답글이 같이 내려오는지 확인")
-	void getPostDetail() {
-
-		Long samplePostId = 1L;
-
-		PostDetailInfoResponse infoResponse = postReadService.getPostDetail(samplePostId);
-
-		System.out.println(infoResponse);
 	}
 
 }


### PR DESCRIPTION
## 작업에 대한 간단한 요약
댓글, 포스트의 좋아요,취소 엔드포인트를 분리하였습니다.

### 변경내역
- 댓글 좋아요/취소 엔드포인트 분리
- 포스트 좋아요/취소 엔드포인트 분리


### 어떤부분에 집중해서 리뷰하면좋을지
프론트엔드분들의 요청사항으로 좋아요/취소 엔드포인트를 분리하였는데, 이 방법 말고 다른 방법이 있을까요?

### 이슈번호 외 기타내용
#34